### PR TITLE
[FEATURE] solve TimeoutErrors + updated Readme for old cached respons…

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ for Puppeteer.
   "restrictedUrlPattern": "((.*(\\.png|\\.jpg|\\.jpeg|\\.gif|\\.webp|\\.mp4)($|\\?))|googleapis\\.com|gstatic\\.com|bat\\.bing\\.com|klarnacdn\\.net|www\\.google\\.com|datatricks\\.com|googletagmanager\\.com)",
   "closeBrowser": false,
   "cache": "filesystem",
-  "timeout": 60000,
+  "timeout": 300000,
   "cacheConfig": {
     "cacheDurationMinutes": 10080,
     "cacheMaxEntries": -1,
@@ -287,4 +287,11 @@ for Puppeteer.
   ]
 }
 
+```
+
+### Additional cronjob to cleanup old crawled pages
+
+```
+## Cleanup old cache files
+0 5 * * * find /mnt/volume_ams3_01/cache/ -maxdepth 1 -type f -mmin +10080 -delete
 ```

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -151,9 +151,12 @@ export class Renderer {
     try {
       // Navigate to page. Wait until there are no oustanding network requests.
       response = await page.goto(requestUrl, {
-        timeout: this.config.timeout,
+        // default minimum timeout should be 300000 because we have a timeout of 60000 for 5 selectors
+        timeout: this.config.timeout > 300000 ? this.config.timeout : 300000,
         waitUntil: 'domcontentloaded',
       });
+      // change default timeout from 30000 to 60000
+      await page.setDefaultTimeout(60000);
       await page.waitForSelector('#toast-root');
       await page.waitForSelector('main > *:nth-child(4) ');
       await page.waitForSelector('[class*="-loadingIndicator__"]', { hidden: true});


### PR DESCRIPTION
…es cleanup

 - updated README with delete files after X minutes > cleanup old cached responses which won't be crawled again
 - setDefaultTimeout = 60000 for waitForSelector > prevents 'TimeoutError: Navigation timeout of 60000 ms exceeded' which was caused by slow GraphQl response
 - minimum goto timeout set to 300000 > prevents 'TimeoutError: waiting for selector' which was caused by slow GraphQl response